### PR TITLE
Add basic PyQt5 prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+presets.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # Rendering.Ai
-For Design Central
+
+A prototype PyQt5 application skeleton for converting sketches into rendered images with AI models.
+
+This repository currently provides a minimal structure, including preset management and project file handling.
+
+## Features
+
+- PyQt5 main window with placeholders for sketch loading and rendering
+- JSON-based preset management (`presets.json`)
+- Basic project file structure (`.srproj`)
+
+This is an early prototype and not a fully functional implementation of the requested system.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyQt5>=5.15
+opencv-python-headless>=4.9

--- a/src/cleanup.py
+++ b/src/cleanup.py
@@ -1,0 +1,22 @@
+import cv2
+import numpy as np
+
+
+def cleanup_image(path: str) -> str:
+    """Return path to cleaned-up image. This function performs simple denoising
+    and contrast adjustment. The result is stored next to the original image
+    with `_clean` suffix."""
+    img = cv2.imread(path)
+    if img is None:
+        raise FileNotFoundError(path)
+
+    denoised = cv2.fastNlMeansDenoisingColored(img, None, 10, 10, 7, 21)
+    lab = cv2.cvtColor(denoised, cv2.COLOR_BGR2LAB)
+    l, a, b = cv2.split(lab)
+    l = cv2.equalizeHist(l)
+    lab = cv2.merge((l, a, b))
+    result = cv2.cvtColor(lab, cv2.COLOR_LAB2BGR)
+
+    out_path = path.rsplit('.', 1)[0] + '_clean.png'
+    cv2.imwrite(out_path, result)
+    return out_path

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,68 @@
+import sys
+from pathlib import Path
+from PyQt5 import QtWidgets, QtGui, QtCore
+
+from presets import load_presets, save_presets, Preset
+from project import Project
+from cleanup import cleanup_image
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Rendering.Ai Prototype")
+        self.resize(800, 600)
+
+        self.image_label = QtWidgets.QLabel("Load a sketch to begin")
+        self.image_label.setAlignment(QtCore.Qt.AlignCenter)
+        self.setCentralWidget(self.image_label)
+
+        self._create_menu()
+        self.presets = load_presets()
+        self.current_project: Project | None = None
+
+    def _create_menu(self):
+        menubar = self.menuBar()
+        file_menu = menubar.addMenu("File")
+        open_action = file_menu.addAction("Open Sketch")
+        open_action.triggered.connect(self.open_sketch)
+        save_action = file_menu.addAction("Save Project")
+        save_action.triggered.connect(self.save_project)
+        file_menu.addSeparator()
+        exit_action = file_menu.addAction("Exit")
+        exit_action.triggered.connect(self.close)
+
+    def open_sketch(self):
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Open Sketch", filter="Images (*.png *.jpg *.jpeg)")
+        if not path:
+            return
+        cleaned = cleanup_image(path)
+        pix = QtGui.QPixmap(cleaned)
+        self.image_label.setPixmap(
+            pix.scaled(self.image_label.size(), QtCore.Qt.KeepAspectRatio))
+        self.current_project = Project(sketch_path=path)
+
+    def save_project(self):
+        if not self.current_project:
+            QtWidgets.QMessageBox.information(self, "Info", "No project to save")
+            return
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Save Project", filter="Sketch Render Project (*.srproj)")
+        if not path:
+            return
+        if not path.endswith('.srproj'):
+            path += '.srproj'
+        self.current_project.save(Path(path))
+        QtWidgets.QMessageBox.information(self, "Saved", f"Project saved to {path}")
+
+
+def main():
+    app = QtWidgets.QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/presets.py
+++ b/src/presets.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+from dataclasses import dataclass, asdict
+from typing import List, Dict, Any
+
+PRESETS_FILE = Path('presets.json')
+
+@dataclass
+class Preset:
+    name: str
+    settings: Dict[str, Any]
+    thumbnail: str | None = None
+
+
+def load_presets() -> List[Preset]:
+    if PRESETS_FILE.exists():
+        with open(PRESETS_FILE, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+            return [Preset(**p) for p in data]
+    return []
+
+
+def save_presets(presets: List[Preset]) -> None:
+    with open(PRESETS_FILE, 'w', encoding='utf-8') as f:
+        json.dump([asdict(p) for p in presets], f, ensure_ascii=False, indent=2)

--- a/src/project.py
+++ b/src/project.py
@@ -1,0 +1,21 @@
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, Any
+
+@dataclass
+class Project:
+    sketch_path: str
+    depth_map_path: str | None = None
+    material_settings: Dict[str, Any] | None = None
+    lighting_settings: Dict[str, Any] | None = None
+
+    def save(self, path: Path) -> None:
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump(asdict(self), f, ensure_ascii=False, indent=2)
+
+    @staticmethod
+    def load(path: Path) -> 'Project':
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        return Project(**data)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,18 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]/"src"))
+from presets import Preset, load_presets, save_presets, PRESETS_FILE
+import os
+
+
+def test_save_load(tmp_path):
+    orig = [Preset(name="test", settings={"a": 1}, thumbnail=None)]
+    old_file = PRESETS_FILE
+    try:
+        test_file = tmp_path / "p.json"
+        globals()['PRESETS_FILE'] = test_file
+        save_presets(orig)
+        loaded = load_presets()
+        assert len(loaded) == 1
+        assert loaded[0].name == "test"
+        assert loaded[0].settings["a"] == 1
+    finally:
+        globals()['PRESETS_FILE'] = old_file


### PR DESCRIPTION
## Summary
- create minimal README and Python requirements
- add PyQt5 application skeleton with sketch loading and preset JSON support
- implement simple cleanup helper using OpenCV
- allow saving/loading presets
- add project save feature
- provide pytest covering preset load/save logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d1e58d62883339f242a05ffec76fb